### PR TITLE
Modified CrossRefStream's Index parsing to interpret argument as an

### DIFF
--- a/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
+++ b/jhove-modules/src/main/java/edu/harvard/hul/ois/jhove/module/PdfModule.java
@@ -1207,9 +1207,10 @@ public class PdfModule
                     _xref = new long [no];
                     _xref2 = new int[no] [];
                 }
-                if (sObjNum < 0 || sObjNum >= no) {
+				if (!xstream.isValidObject(sObjNum)) {
+					//                if (sObjNum < 0 || sObjNum >= no) {
                     throw new PdfMalformedException 
-                          ("Invalid object number in cross-reference stream", 
+						("Invalid object number in cross-reference stream " + Integer.toString(sObjNum) + " out of " + Integer.toString(no), 
                           _parser.getOffset ());
                 }
                 _xref[sObjNum] = _startxref;  // insert the index of the xref stream itself


### PR DESCRIPTION
Addressing issue #96: CrossRefStream incorrectly assumes /Index value is a 2 element array

array containing an arbitrary set of starting object number and object
count pairs instead of a single pair.

Calculate number of objects using final start/count pair.  (Actual number
will be less than or equal to this value.)

Modified reading loop to read only objects in the index ranges.

Modified PdfModule to test object number against stream's index instead of
a range from 0 to the last object number.

Attempt to conform to PDF specification
http://wwwimages.adobe.com/content/dam/Adobe/en/devnet/pdf/pdfs/pdf_reference_archives/PDFReference15_v6.pdf, page 83 and PDF versions 1.6 and 1.7.